### PR TITLE
Update font due to differences in chrome and safari for fantasy font

### DIFF
--- a/src/features/pokedex/PokedexCard.tsx
+++ b/src/features/pokedex/PokedexCard.tsx
@@ -23,8 +23,8 @@ export function PokedexCard() {
         <Box alignSelf="center">
         </Box>
         <Image fit="contain" src={pokemonDetails.sprite}/>
-        <Box flex direction="row" pad="xsmall" justify="between" margin={{bottom:"-100px"}}>
-            <Box>
+        <Box flex direction="row" pad="small" justify="between" margin={{bottom:"-50px"}}>
+            <Box margin="small">
                 <Text>Species: {pokemonDetails.species}</Text>
                 <Text>Weight: {pokemonDetails.weight}</Text>
                 <Text>Height: {pokemonDetails.height}</Text>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ import { Grommet } from 'grommet';
 const theme = {
   global: {
     font: {
-      family: 'fantasy',
+      family: 'impact',
       size: '18px'
     }
   }


### PR DESCRIPTION
I updated the font that was being used. After checking the styles on chrome I realized that Safari had a much different interpretation of the fantasy font I was using. In safari, fantasy is distracting and slightly unreadable so I went with a much more standard and readable font called 'impact'.


https://github.com/jasoncollins111/pokedex/assets/8008817/dec34551-2dd6-4817-8c44-48201f84f67a

